### PR TITLE
인터뷰 게시글 조회에 캐시를 추가

### DIFF
--- a/app/src/main/java/com/example/bookclub/controller/InterviewController.java
+++ b/app/src/main/java/com/example/bookclub/controller/InterviewController.java
@@ -5,6 +5,7 @@ import com.example.bookclub.domain.account.Account;
 import com.example.bookclub.dto.InterviewDto;
 import com.example.bookclub.dto.PageResultDto;
 import com.example.bookclub.security.UserAccount;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -40,6 +41,7 @@ public class InterviewController {
      * @return 인터뷰 조회 페이지
      */
     @GetMapping
+    @Cacheable(cacheNames = "Interviews", key = "#pageable.pageNumber")
     public String interviewLists(@AuthenticationPrincipal UserAccount userAccount, Model model,
                                  @PageableDefault(size=10, sort="id", direction= Sort.Direction.ASC) Pageable pageable,
                                  @RequestParam(defaultValue = "") String search) {

--- a/app/src/main/java/com/example/bookclub/controller/api/InterviewApiController.java
+++ b/app/src/main/java/com/example/bookclub/controller/api/InterviewApiController.java
@@ -3,6 +3,7 @@ package com.example.bookclub.controller.api;
 import com.example.bookclub.application.interview.InterviewService;
 import com.example.bookclub.common.response.CommonResponse;
 import com.example.bookclub.domain.interview.Interview;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -34,6 +35,7 @@ public class InterviewApiController {
 	@PreAuthorize("hasAuthority('ADMIN')")
 	@PostMapping
 	@ResponseStatus(HttpStatus.CREATED)
+	@CacheEvict(cacheNames = "Interviews", allEntries = true)
 	public CommonResponse<List<Interview>> create() {
 		List<Interview> response = interviewService.crawlAllInterviews();
 		return CommonResponse.success(response);


### PR DESCRIPTION
인터뷰는 매일 밤 크롤링을 통해서 인터파크의 인터뷰를 가져와 저장합니다

조회에는 캐시 생성 및 사용을, 생성에는 캐시 삭제를 합니다

closes #107 